### PR TITLE
Do not prepend working directory, if path is already absolute

### DIFF
--- a/file.bash
+++ b/file.bash
@@ -20,7 +20,10 @@ cmd_store() {
     local passfile="$PREFIX/$path.gpg"
 
     cd $OLDPWD # fix for relative paths
-    local file_abs_path="$OLDPWD/$file"
+    case "$file" in
+        /*) local file_abs_path="$file";;
+        *) local file_abs_path="$OLDPWD/$file";;
+    esac
 
     check_sneaky_paths "$1"
     set_git "$passfile"


### PR DESCRIPTION
Adding a file with an absolute path causes the current working directory to be prepended in front of that absolute path. This patch only prepends OLDPWD, if the path doesn't already start with a slash.